### PR TITLE
Fixed a typo. "Instalation" to "Installation"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Some of the sources are mentioned below:
 * `gnome-shell-extensions <http://git.gnome.org/browse/gnome-shell-extensions/>`_
 
 
-Instalation
+Installation
 ===========
   
 The BinaryClock@zdyb.tk directory should be copied to


### PR DESCRIPTION
I'm going to be working a bit to help clean up my fork for AnalogClock. And in the mean-time, figured I'd submit any fixes or nit-picky things I saw.

All the best,

-Sam
