### PR TITLE
Compatibility with GNOME 3.4

### DIFF
--- a/BinaryClock@zdyb.tk/extension.js
+++ b/BinaryClock@zdyb.tk/extension.js
@@ -136,14 +136,6 @@ BinaryClock.prototype = {
         this.date_menu.actor.add_style_class_name("binary-clock");
         
         this.binary_clock.queue_repaint();
-        
-        let children = this.date_menu.menu.box.get_children();
-        for each(let c in children) {
-            if(c.name == "calendarArea") {
-                c.get_children()[0].insert_actor(this.time_label, 0);
-                break;
-            }
-        }
         this.Run();
     },
     
@@ -152,14 +144,6 @@ BinaryClock.prototype = {
         this.date_menu.actor.remove_style_class_name("binary-clock");
         this.date_menu.actor.remove_actor(this.binary_clock);
         this.date_menu.actor.add_actor(this.orig_clock);
-        
-        let children = this.date_menu.menu.box.get_children();
-        for each(let c in children) {
-            if(c.name == "calendarArea") {
-                c.get_children()[0].remove_actor(this.time_label);
-                break;
-            }
-        }
     }
 }
 

--- a/BinaryClock@zdyb.tk/metadata.json
+++ b/BinaryClock@zdyb.tk/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["3.2"],
+  "shell-version": ["3.4"],
   "uuid": "BinaryClock@zdyb.tk",
   "name": "Binary Clock",
   "description": "Shows a binary clock on panel instead of the default one",


### PR DESCRIPTION
Hi,
The clock actor seems to be automagicaly added since GNOME 3.4. So, no need to add it by hand (anyway, it failed to add). It will probably break the compatibility with GNOME≤3.2, though… I don't know if there is a way to check for g-s version from an extension… (I never took a look at extensions before this one).

Anyway, do whatever you want with this, it's just a hint for what don't work with g-s 3.4.
